### PR TITLE
Fix: clean by image name

### DIFF
--- a/shepherd
+++ b/shepherd
@@ -60,7 +60,7 @@ update_services() {
 
           if [[ "$image_autoclean_limit" != "" ]]; then
             logger "Cleaning up old docker images, leaving last $image_autoclean_limit"
-            img_name=$(docker service inspect "$name" -f '{{.PreviousSpec.TaskTemplate.ContainerSpec.Image}}' | awk -F'/|:' '{print $2}')
+            img_name=$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}' | awk -F'/|:' '{print $2}')
             image_ids=$(docker images -aq --filter=reference=*/$img_name)
             image_ids_count=$(echo $image_ids | wc -w)
             if [[ $image_ids_count > $image_autoclean_limit ]]; then

--- a/shepherd
+++ b/shepherd
@@ -60,7 +60,7 @@ update_services() {
 
           if [[ "$image_autoclean_limit" != "" ]]; then
             logger "Cleaning up old docker images, leaving last $image_autoclean_limit"
-            img_name=$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}' | awk -F'/|:' '{print $2}')
+            img_name=$(docker service inspect "$name" -f '{{.Spec.TaskTemplate.ContainerSpec.Image}}' | awk -F':' '{print $1}')
             image_ids=$(docker images -aq --filter=reference=*/$img_name)
             image_ids_count=$(echo $image_ids | wc -w)
             if [[ $image_ids_count > $image_autoclean_limit ]]; then

--- a/shepherd
+++ b/shepherd
@@ -60,7 +60,8 @@ update_services() {
 
           if [[ "$image_autoclean_limit" != "" ]]; then
             logger "Cleaning up old docker images, leaving last $image_autoclean_limit"
-            image_ids=$(docker images -a --filter=reference='*/$name*' | awk '{print $3}')
+            img_name=$(docker service inspect "$name" -f '{{.PreviousSpec.TaskTemplate.ContainerSpec.Image}}' | awk -F'/|:' '{print $2}')
+            image_ids=$(docker images -aq --filter=reference=*/$img_name)
             image_ids_count=$(echo $image_ids | wc -w)
             if [[ $image_ids_count > $image_autoclean_limit ]]; then
               docker container prune -f


### PR DESCRIPTION
Clean images by image name instead of service name